### PR TITLE
use config.js file for deployment envvars

### DIFF
--- a/packages/template-stocky37/public/config.js
+++ b/packages/template-stocky37/public/config.js
@@ -1,0 +1,4 @@
+// example template for this file:
+// window.env = Object.freeze({
+// 	REACT_APP_API_URL: 'http://localhost:8080',
+// });

--- a/packages/template-stocky37/public/index.html
+++ b/packages/template-stocky37/public/index.html
@@ -12,6 +12,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
 		<link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+		<script type="text/javascript" src="%PUBLIC_URL%/config.js"></script>
 		<!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/packages/template-stocky37/src/util/api.js
+++ b/packages/template-stocky37/src/util/api.js
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import {useQuery} from 'react-query';
-
-const API_URL = 'http://localhost:8080';
+import {API_URL} from './env';
 
 const fetcher = (path) => fetch(`${API_URL}/${path}`).then((res) => res.json());
 

--- a/packages/template-stocky37/src/util/env.js
+++ b/packages/template-stocky37/src/util/env.js
@@ -1,0 +1,11 @@
+const env = (key, defaultValue = undefined) => {
+	if (window['env'] && window['env'].hasOwnProperty(key)) {
+		return window['env'][key];
+	}
+	if (process.env.hasOwnProperty(key)) {
+		return process.env[key];
+	}
+	return defaultValue;
+};
+
+export const API_URL = env('REACT_APP_API_URL', 'http://localhost:8080');


### PR DESCRIPTION
- can still use `REACT_APP` environment variables locally
- config.js file should be configured and deployed per environment

Closes #14 